### PR TITLE
Fix folder check when creating database

### DIFF
--- a/app/src/main/java/com/stipess/youplay/database/YouPlayDatabase.java
+++ b/app/src/main/java/com/stipess/youplay/database/YouPlayDatabase.java
@@ -173,7 +173,7 @@ public class YouPlayDatabase extends SQLiteOpenHelper
     private String getPath(String database)
     {
         Log.d(TAG, "Napravi bazu folder: " + database);
-        if(FileManager.getDatabaseFolder().exists())
+        if(!FileManager.getDatabaseFolder().exists())
             FileManager.getDatabaseFolder().mkdirs();
 
         File base = new File(Environment.getExternalStorageDirectory() + File.separator +


### PR DESCRIPTION
## Summary
- ensure database directory is created if missing

## Testing
- `./gradlew test` *(fails: unable to download gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_6844236918dc832c8e4654fa916bca9c