### PR TITLE
Remove deprecated useProguard option

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,7 +26,6 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            useProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             android.applicationVariants.all { variant ->
                 variant.outputs.all {
@@ -36,7 +35,6 @@ android {
         }
         debug {
             minifyEnabled false
-            useProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             android.applicationVariants.all { variant ->
                 variant.outputs.all {


### PR DESCRIPTION
## Summary
- remove `useProguard` which is no longer supported in recent AGP versions

## Testing
- `./gradlew tasks --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68442b948704832c9668df2581538246