### PR TITLE
Fix missing namespace

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'io.fabric'
 
 android {
+    namespace 'com.stipess.youplay'
 
     compileSdkVersion 34
     buildToolsVersion '34.0.0'


### PR DESCRIPTION
## Summary
- specify `namespace` in the Android module

## Testing
- `./gradlew --version` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68442c7da5dc832cac749800769d7bc0