### PR TITLE
Fix build by removing Fabric plugin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'io.fabric'
 
 android {
     namespace 'com.stipess.youplay'
@@ -107,19 +106,5 @@ repositories {
     maven { url 'https://s3.amazonaws.com/moat-sdk-builds' }
     google()
 
-}
-buildscript {
-    repositories {
-        maven { url 'https://maven.fabric.io/public' }
-    }
-
-    dependencies {
-        // These docs use an open ended version so that our plugin
-        // can be updated quickly in response to Android tooling updates
-
-        // We recommend changing it to the latest version from our changelog:
-        // https://docs.fabric.io/android/changelog.html#fabric-gradle-plugin
-        classpath 'io.fabric.tools:gradle:1.31.2'
-    }
 }
 apply plugin: 'com.google.gms.google-services'


### PR DESCRIPTION
## Summary
- remove the outdated Fabric Crashlytics Gradle plugin

## Testing
- `./gradlew tasks --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68442d9a7c60832c9cfcd2c261e5b6a0