### PR TITLE
Fix build config feature

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,9 @@ android {
     namespace 'com.stipess.youplay'
 
     compileSdkVersion 35
+    buildFeatures {
+        buildConfig true
+    }
     lintOptions {
         checkReleaseBuilds false
         abortOnError false


### PR DESCRIPTION
## Summary
- enable BuildConfig generation because app uses `buildConfigField`

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68443ada143c832c80720929aaede189