### PR TITLE
Fix repository

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,9 +101,6 @@ repositories {
     jcenter()
     maven { url "https://jitpack.io" }
     maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
-    maven {
-        url "https://cdn01.static.adfalcon.com/sdk/android/maven"
-    }
     maven { url 'https://s3.amazonaws.com/moat-sdk-builds' }
 
 }


### PR DESCRIPTION
## Summary
- remove the failing adfalcon repository that caused 502 errors

## Testing
- `./gradlew assembleDebug` *(fails: unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68443ffe5058832c8dd5efb55cf8a205