### PR TITLE
Fix gradle clean task configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,6 @@ allprojects {
     }
 }
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
+tasks.register("clean", Delete) {
+    delete(rootProject.layout.buildDirectory)
 }


### PR DESCRIPTION
## Summary
- avoid unnecessary task configuration in `build.gradle`

## Testing
- `./gradlew help` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6844411d0cc8832cbd17f1b61229be90