### PR TITLE
Fix NewPipeExtractor dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,7 +71,8 @@ dependencies {
     implementation 'com.liulishuo.filedownloader:library:1.7.7'
     implementation 'com.google.firebase:firebase-analytics:22.4.0'
 
-    implementation 'org.schabi.newpipe:extractor:0.23.3'
+    // Use NewPipeExtractor from JitPack instead of the deprecated repository
+    implementation 'com.github.TeamNewPipe:NewPipeExtractor:v0.23.3'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'org.jsoup:jsoup:1.17.1'
     implementation 'com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751'
@@ -101,7 +102,6 @@ repositories {
     jcenter()
     maven { url "https://jitpack.io" }
     maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
-    maven { url 'https://s3.amazonaws.com/moat-sdk-builds' }
 
 }
 apply plugin: 'com.google.gms.google-services'


### PR DESCRIPTION
## Summary
- fetch `NewPipeExtractor` from JitPack
- remove obsolete S3 repository

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684444c67f70832c86efc98f9bfde711