### PR TITLE
Fix Android build config and migrate to AndroidX

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,7 +60,7 @@ java {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
 
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     implementation 'androidx.recyclerview:recyclerview:1.4.0'
     implementation 'com.github.bumptech.glide:glide:4.16.0'
     implementation 'de.hdodenhof:circleimageview:3.1.0'
@@ -74,7 +74,7 @@ dependencies {
     // Use NewPipeExtractor from JitPack instead of the deprecated repository
     implementation 'com.github.TeamNewPipe:NewPipeExtractor:0.23.3'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
-    implementation 'org.jsoup:jsoup:1.17.1'
+    implementation 'org.jsoup:jsoup:1.17.2'
     implementation 'com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751'
 
     implementation 'androidx.multidex:multidex:2.0.1'
@@ -86,11 +86,11 @@ dependencies {
 
     implementation 'com.google.android.material:material:1.12.0'
     implementation 'androidx.preference:preference:1.2.1'
-    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'com.google.gms:google-services:4.4.2'
     implementation 'com.google.android.exoplayer:exoplayer:2.19.1'
+    implementation 'androidx.media:media:1.7.0'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.13.0'
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'
 
@@ -99,7 +99,6 @@ dependencies {
 repositories {
     google()
     mavenCentral()
-    jcenter()
     maven { url "https://jitpack.io" }
     maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
 

--- a/app/src/main/java/com/stipess/youplay/AudioService.java
+++ b/app/src/main/java/com/stipess/youplay/AudioService.java
@@ -18,13 +18,13 @@ import android.os.Binder;
 import android.os.Build;
 import android.os.IBinder;
 import android.os.RemoteException;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 
-import android.support.v4.media.MediaDescriptionCompat;
-import android.support.v4.media.MediaMetadataCompat;
-import android.support.v4.media.session.MediaControllerCompat;
-import android.support.v4.media.session.MediaSessionCompat;
-import android.support.v4.media.session.PlaybackStateCompat;
+import androidx.media.MediaDescriptionCompat;
+import androidx.media.MediaMetadataCompat;
+import androidx.media.session.MediaControllerCompat;
+import androidx.media.session.MediaSessionCompat;
+import androidx.media.session.PlaybackStateCompat;
 import android.util.Log;
 import android.widget.RemoteViews;
 

--- a/app/src/main/java/com/stipess/youplay/MainActivity.java
+++ b/app/src/main/java/com/stipess/youplay/MainActivity.java
@@ -16,7 +16,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.os.StrictMode;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.View;

--- a/app/src/main/java/com/stipess/youplay/fragments/PlayFragment.java
+++ b/app/src/main/java/com/stipess/youplay/fragments/PlayFragment.java
@@ -13,7 +13,7 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -26,7 +26,7 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.recyclerview.widget.SimpleItemAnimator;
 
-import android.support.v4.media.session.PlaybackStateCompat;
+import androidx.media.session.PlaybackStateCompat;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.KeyEvent;

--- a/app/src/main/java/com/stipess/youplay/fragments/SearchFragment.java
+++ b/app/src/main/java/com/stipess/youplay/fragments/SearchFragment.java
@@ -11,7 +11,7 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.Uri;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;

--- a/app/src/main/java/com/stipess/youplay/fragments/SettingsFragment.java
+++ b/app/src/main/java/com/stipess/youplay/fragments/SettingsFragment.java
@@ -9,7 +9,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
-import android.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 import android.util.Log;
 import android.view.View;
 import android.view.Window;

--- a/app/src/main/java/com/stipess/youplay/player/AudioPlayer.java
+++ b/app/src/main/java/com/stipess/youplay/player/AudioPlayer.java
@@ -7,14 +7,14 @@ import android.util.Log;
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.DefaultLoadControl;
 import com.google.android.exoplayer2.DefaultRenderersFactory;
-import com.google.android.exoplayer2.ExoPlayerFactory;
+import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.Player;
-import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory;
 import com.google.android.exoplayer2.extractor.ExtractorsFactory;
-import com.google.android.exoplayer2.source.ExtractorMediaSource;
 import com.google.android.exoplayer2.source.MediaSource;
+import com.google.android.exoplayer2.source.ProgressiveMediaSource;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
+import com.google.android.exoplayer2.MediaItem;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
 import com.google.android.exoplayer2.util.Util;
 import com.stipess.youplay.AudioService;
@@ -45,11 +45,11 @@ import java.util.Collections;
  * along with YouPlay.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public class AudioPlayer implements Player.EventListener{
+public class AudioPlayer implements Player.Listener{
 
     private AudioService audioService = AudioService.getInstance();
 
-    private SimpleExoPlayer exoPlayer;
+    private ExoPlayer exoPlayer;
     // Lista pjesama
     private ArrayList<Music> musicList = new ArrayList<>();
     // Kopija lista pjesama za shuffle
@@ -107,7 +107,11 @@ public class AudioPlayer implements Player.EventListener{
 
     public AudioPlayer(Context context) {
         this.context = context;
-        exoPlayer = ExoPlayerFactory.newSimpleInstance(context, new DefaultRenderersFactory(context), new DefaultTrackSelector(), new DefaultLoadControl());
+        exoPlayer = new ExoPlayer.Builder(context)
+                .setRenderersFactory(new DefaultRenderersFactory(context))
+                .setTrackSelector(new DefaultTrackSelector(context))
+                .setLoadControl(new DefaultLoadControl())
+                .build();
         exoPlayer.addListener(this);
     }
 
@@ -238,11 +242,12 @@ public class AudioPlayer implements Player.EventListener{
         currentlyPlaying = music;
         currentlyPlayingStation = null;
         Uri uri = Uri.parse(music.getPath());
-        DefaultDataSourceFactory dataSourceFactory = new DefaultDataSourceFactory(context, Util.getUserAgent(context, "YouPlay"), null);
+        DefaultDataSourceFactory dataSourceFactory = new DefaultDataSourceFactory(context, Util.getUserAgent(context, "YouPlay"));
         ExtractorsFactory extractorsFactory = new DefaultExtractorsFactory();
-        MediaSource mediaSource = new ExtractorMediaSource(uri, dataSourceFactory, extractorsFactory, null, null);
-        exoPlayer.setAudioStreamType(C.STREAM_TYPE_MUSIC);
-        exoPlayer.prepare(mediaSource);
+        MediaSource mediaSource = new ProgressiveMediaSource.Factory(dataSourceFactory, extractorsFactory)
+                .createMediaSource(MediaItem.fromUri(uri));
+        exoPlayer.setMediaSource(mediaSource);
+        exoPlayer.prepare();
         exoPlayer.setPlayWhenReady(true);
     }
 
@@ -250,11 +255,12 @@ public class AudioPlayer implements Player.EventListener{
         currentlyPlayingStation = station;
         currentlyPlaying = null;
         Uri uri = Uri.parse(station.getUrl());
-        DefaultDataSourceFactory dataSourceFactory = new DefaultDataSourceFactory(context, Util.getUserAgent(context, "YouPlay"), null);
+        DefaultDataSourceFactory dataSourceFactory = new DefaultDataSourceFactory(context, Util.getUserAgent(context, "YouPlay"));
         ExtractorsFactory extractorsFactory = new DefaultExtractorsFactory();
-        MediaSource mediaSource = new ExtractorMediaSource(uri, dataSourceFactory, extractorsFactory, null, null);
-        exoPlayer.setAudioStreamType(C.STREAM_TYPE_MUSIC);
-        exoPlayer.prepare(mediaSource);
+        MediaSource mediaSource = new ProgressiveMediaSource.Factory(dataSourceFactory, extractorsFactory)
+                .createMediaSource(MediaItem.fromUri(uri));
+        exoPlayer.setMediaSource(mediaSource);
+        exoPlayer.prepare();
         exoPlayer.setPlayWhenReady(true);
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.10.1'
@@ -19,7 +18,6 @@ allprojects {
         google()
         mavenCentral()
         maven { url "https://jitpack.io" }
-        jcenter()
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,4 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 android.useAndroidX=true
 android.enableJetifier=true
+android.suppressUnsupportedCompileSdk=35


### PR DESCRIPTION
## Summary
- drop `jcenter()` repos
- update app dependencies
- migrate PreferenceManager and media session imports to AndroidX
- update ExoPlayer setup to use Builder API
- add unsupported compile SDK suppression

## Testing
- `gradle assembleDebug` *(fails: Could not resolve com.android.tools.build:gradle:8.10.1)*

------
https://chatgpt.com/codex/tasks/task_e_684446fc5c84832c95e8fa3f19bb6a5e