### PR TITLE
Fix NewPipeExtractor Maven coordinate

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,8 +71,8 @@ dependencies {
     implementation 'com.liulishuo.filedownloader:library:1.7.7'
     implementation 'com.google.firebase:firebase-analytics:22.4.0'
 
-    // Use NewPipeExtractor from JitPack instead of the deprecated repository
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:0.23.3'
+    // Use NewPipeExtractor from JitPack (tagged releases use "v" prefix)
+    implementation 'com.github.TeamNewPipe:NewPipeExtractor:v0.23.3'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'org.jsoup:jsoup:1.17.2'
     implementation 'com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751'


### PR DESCRIPTION
## Summary
- fix dependency coordinate for NewPipeExtractor so it resolves via JitPack

## Testing
- `gradle assembleDebug` *(fails: Could not GET gradle artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_68444b001b1c832ca2a70a2984090c73