### PR TITLE
Fix NewPipeExtractor dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,8 +71,11 @@ dependencies {
     implementation 'com.liulishuo.filedownloader:library:1.7.7'
     implementation 'com.google.firebase:firebase-analytics:22.4.0'
 
-    // Use NewPipeExtractor from JitPack (tagged releases use "v" prefix)
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:v0.23.3'
+    // Use NewPipeExtractor from JitPack
+    // Older versions used the "v" prefix in the tag name, but the latest
+    // releases are published without it. Use the version number directly so
+    // Gradle can resolve the artifact from JitPack.
+    implementation 'com.github.TeamNewPipe:NewPipeExtractor:0.23.3'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'org.jsoup:jsoup:1.17.2'
     implementation 'com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751'


### PR DESCRIPTION
## Summary
- adjust `NewPipeExtractor` dependency format

## Testing
- `./gradlew test --stacktrace` *(fails: Unable to download Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68444c11fad4832c90f9363ef02b3d93