### PR TITLE
Fix deprecation warnings in build files

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -102,8 +102,12 @@ dependencies {
 repositories {
     google()
     mavenCentral()
-    maven { url "https://jitpack.io" }
-    maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+    maven {
+        url = uri("https://jitpack.io")
+    }
+    maven {
+        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+    }
 
 }
 apply plugin: 'com.google.gms.google-services'

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,9 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven { url "https://jitpack.io" }
+        maven {
+            url = uri("https://jitpack.io")
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- fix Groovy DSL space-assignment warnings by assigning the `url` property in `maven` repository blocks

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68444efe98ac832c867f59397f4f0295