### PR TITLE
Fix NewPipeExtractor coordinates

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,11 +71,8 @@ dependencies {
     implementation 'com.liulishuo.filedownloader:library:1.7.7'
     implementation 'com.google.firebase:firebase-analytics:22.4.0'
 
-    // Use NewPipeExtractor from JitPack
-    // Older versions used the "v" prefix in the tag name, but the latest
-    // releases are published without it. Use the version number directly so
-    // Gradle can resolve the artifact from JitPack.
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:0.23.3'
+    // Use NewPipeExtractor from Maven Central
+    implementation 'org.schabi.newpipe:extractor:0.27.7'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'org.jsoup:jsoup:1.17.2'
     implementation 'com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751'

--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,9 @@ buildscript {
 
 allprojects {
     repositories {
+        maven { url "https://jitpack.io" }
         google()
         mavenCentral()
-        maven { url "https://jitpack.io" }
     }
 }
 


### PR DESCRIPTION
## Summary
- get JitPack repository listed first so gradle can access it
- switch to Maven Central artifact `org.schabi.newpipe:extractor:0.27.7`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68445042cad4832c8bda91266dd46c82