### PR TITLE
Update NewPipeExtractor dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,8 +71,8 @@ dependencies {
     implementation 'com.liulishuo.filedownloader:library:1.7.7'
     implementation 'com.google.firebase:firebase-analytics:22.4.0'
 
-    // Use NewPipeExtractor from Maven Central
-    implementation 'org.schabi.newpipe:extractor:0.27.7'
+    // Use NewPipeExtractor from JitPack
+    implementation 'com.github.TeamNewPipe.NewPipeExtractor:NewPipeExtractor:v0.24.1'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'org.jsoup:jsoup:1.17.2'
     implementation 'com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751'


### PR DESCRIPTION
## Summary
- switch to NewPipeExtractor 0.24.1 from JitPack

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684459a3e3a4832c9ee1a8bc7209ae13