### PR TITLE
Fix Android 12 manifest requirements

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,7 +27,8 @@
             android:name="com.stipess.youplay.MainActivity"
             android:launchMode="singleTask"
             android:theme="@style/AppThemeLauncher"
-            android:screenOrientation="portrait">
+            android:screenOrientation="portrait"
+            android:exported="true">
             <intent-filter>
                 <action
                     android:name="android.intent.action.MAIN"
@@ -51,7 +52,9 @@
             android:name="com.stipess.youplay.listeners.ButtonListener"
             android:exported="false" />
 
-        <receiver android:name="com.stipess.youplay.listeners.AudioOutputListener">
+        <receiver
+            android:name="com.stipess.youplay.listeners.AudioOutputListener"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MEDIA_BUTTON" />
             </intent-filter>


### PR DESCRIPTION
## Summary
- declare exported property for launcher activity
- declare exported property for broadcast receiver

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684465174060832cb96aec3d11c5a9ff