### PR TITLE
Fix instrumentation test imports

### DIFF
--- a/app/src/androidTest/java/com/stipess/youplay/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/com/stipess/youplay/ExampleInstrumentedTest.java
@@ -1,8 +1,8 @@
 package com.stipess.youplay;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -19,8 +19,8 @@ public class ExampleInstrumentedTest {
     @Test
     public void useAppContext() throws Exception {
         // Context of the app under test.
-        Context appContext = InstrumentationRegistry.getTargetContext();
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
-        assertEquals("com.hfad.youplay", appContext.getPackageName());
+        assertEquals("com.stipess.youplay", appContext.getPackageName());
     }
 }


### PR DESCRIPTION
## Summary
- use AndroidX instrumentation test packages
- update test to check the correct package name

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68446a4d7288832c81a5c0ce998275ca