### PR TITLE
Fix targetSdkVersion assignment

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
     defaultConfig {
         applicationId "com.stipess.youplay"
         minSdkVersion 21
-        targetSdkVersion = 35
+        targetSdkVersion 35
         versionCode = 73
         versionName = "2.2.0"
         buildConfigField 'String', 'YOUPLAY_WEBSITE', '"https://youplayandroid.com"'


### PR DESCRIPTION
## Summary
- remove assignment operator from `targetSdkVersion`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68447e42339c832ca5c21dd091ef6b16