### PR TITLE
Remove deprecated threading APIs

### DIFF
--- a/app/src/main/java/com/stipess/youplay/AudioService.java
+++ b/app/src/main/java/com/stipess/youplay/AudioService.java
@@ -29,7 +29,6 @@ import android.widget.RemoteViews;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.app.JobIntentService;
 import androidx.core.app.NotificationCompat;
 import androidx.core.content.ContextCompat;
 import androidx.media.session.MediaButtonReceiver;
@@ -73,7 +72,9 @@ import static com.stipess.youplay.utils.Constants.*;
  * along with YouPlay.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public class AudioService extends JobIntentService implements AudioManager.OnAudioFocusChangeListener
+import android.app.Service;
+
+public class AudioService extends Service implements AudioManager.OnAudioFocusChangeListener
 {
 
     private static final String TAG = AudioService.class.getSimpleName();
@@ -469,10 +470,6 @@ public class AudioService extends JobIntentService implements AudioManager.OnAud
             manager.notify(NOTIFICATION_ID, notification);
     }
 
-    @Override
-    protected void onHandleWork(@NonNull Intent intent) {
-
-    }
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId)

--- a/app/src/main/java/com/stipess/youplay/fragments/PlayFragment.java
+++ b/app/src/main/java/com/stipess/youplay/fragments/PlayFragment.java
@@ -9,7 +9,6 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.media.AudioManager;
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
@@ -1228,7 +1227,7 @@ public class PlayFragment extends BaseFragment implements View.OnClickListener,
         String getYoutubeLink = YOUTUBELINK + pjesma.getId();
 
         if(urlLoader != null)
-            urlLoader.cancel(true);
+            urlLoader = null;
 
         urlLoader = new UrlLoader(getYoutubeLink, relatedVideos, audioService.getAudioPlayer().getMusicList());
         urlLoader.setListener(new UrlLoader.Listener() {
@@ -1256,13 +1255,13 @@ public class PlayFragment extends BaseFragment implements View.OnClickListener,
                 }
             }
         });
-        urlLoader.execute();
+        urlLoader.load();
     }
 
     private void updateTable(Music pjesma)
     {
         new DatabaseHandler(pjesma, TABLE_NAME, YouPlayDatabase.YOUPLAY_DB, DatabaseHandler.UpdateType.ADD).
-                setDataChangedListener(this).executeOnExecutor(AsyncTask.SERIAL_EXECUTOR);
+                setDataChangedListener(this).execute();
     }
 
     @Override

--- a/app/src/main/java/com/stipess/youplay/radio/Browser.java
+++ b/app/src/main/java/com/stipess/youplay/radio/Browser.java
@@ -1,10 +1,16 @@
 package com.stipess.youplay.radio;
 
-import android.os.AsyncTask;
+import android.os.Handler;
+import android.os.Looper;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 import java.util.ArrayList;
 
-public abstract class Browser extends AsyncTask<String, String, String> {
+public abstract class Browser {
+
+    private static final Executor EXECUTOR = Executors.newSingleThreadExecutor();
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
 
     public enum ListType
     {
@@ -23,4 +29,17 @@ public abstract class Browser extends AsyncTask<String, String, String> {
 
     public abstract void setListener(Listener listener);
 
+    protected void onPreExecute() {}
+
+    protected String doInBackground(String... strings) { return null; }
+
+    protected void onPostExecute(String result) {}
+
+    public void execute(final String... args) {
+        mainHandler.post(this::onPreExecute);
+        EXECUTOR.execute(() -> {
+            String res = doInBackground(args);
+            mainHandler.post(() -> onPostExecute(res));
+        });
+    }
 }

--- a/app/src/main/java/com/stipess/youplay/radio/RadioBrowser.java
+++ b/app/src/main/java/com/stipess/youplay/radio/RadioBrowser.java
@@ -26,19 +26,16 @@ public class RadioBrowser extends Browser
         this.type = type;
     }
 
-    @Override
     protected void onPreExecute()
     {
         if(listener != null)
             listener.preExecute();
     }
 
-    @Override
     public void setListener(Listener listener) {
         this.listener = listener;
     }
 
-    @Override
     protected String doInBackground(String... strings)
     {
         if(type == ListType.COUNTRIES)
@@ -93,7 +90,6 @@ public class RadioBrowser extends Browser
         return null;
     }
 
-    @Override
     protected void onPostExecute(String s)
     {
         if(type == ListType.COUNTRIES && listener != null)

--- a/app/src/main/java/com/stipess/youplay/radio/StationBrowser.java
+++ b/app/src/main/java/com/stipess/youplay/radio/StationBrowser.java
@@ -28,7 +28,6 @@ public class StationBrowser extends Browser
         this.country = country;
     }
 
-    @Override
     protected void onPreExecute() {
         if(listener != null)
             listener.preExecute();
@@ -38,12 +37,10 @@ public class StationBrowser extends Browser
         return country;
     }
 
-    @Override
     public void setListener(Listener listener) {
         this.listener = listener;
     }
 
-    @Override
     protected String doInBackground(String... strings) {
         if(type == ListType.STATIONS)
         {
@@ -97,7 +94,6 @@ public class StationBrowser extends Browser
         return null;
     }
 
-    @Override
     protected void onPostExecute(String s) {
         if(listener != null)
             listener.getPostExecute(stations);


### PR DESCRIPTION
## Summary
- replace JobIntentService with plain Service
- swap AsyncTask-based DatabaseHandler with ExecutorService
- migrate UrlLoader and YouPlayWeb to ExecutorService
- rework Browser hierarchy to use ExecutorService
- update fragment code for new loaders

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68447ea6a084832cb5f1d4b3fd56bb5d