### PR TITLE
Refactor deprecated Android APIs

### DIFF
--- a/app/src/main/java/com/stipess/youplay/AudioService.java
+++ b/app/src/main/java/com/stipess/youplay/AudioService.java
@@ -496,12 +496,20 @@ public class AudioService extends Service implements AudioManager.OnAudioFocusCh
     {
         if(intent != null)
         {
-            if(intent.getParcelableExtra(SONG) != null && !audioPlayer.isStream())
+            if(intent.hasExtra(SONG) && !audioPlayer.isStream())
             {
-                music = intent.getParcelableExtra(SONG);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+                    music = intent.getParcelableExtra(SONG, Music.class);
+                else
+                    music = intent.getParcelableExtra(SONG);
             }
-            else if(audioPlayer.isStream() && intent.getParcelableExtra(SONG) != null)
-                station = intent.getParcelableExtra(SONG);
+            else if(audioPlayer.isStream() && intent.hasExtra(SONG))
+            {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+                    station = intent.getParcelableExtra(SONG, Station.class);
+                else
+                    station = intent.getParcelableExtra(SONG);
+            }
 
 
             switch (intent.getIntExtra(ACTION,0))

--- a/app/src/main/java/com/stipess/youplay/MainActivity.java
+++ b/app/src/main/java/com/stipess/youplay/MainActivity.java
@@ -40,6 +40,7 @@ import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentPagerAdapter;
 import androidx.activity.OnBackPressedCallback;
 import androidx.viewpager.widget.ViewPager;
+import androidx.core.content.ContextCompat;
 
 import com.google.android.material.tabs.TabLayout;
 import com.google.firebase.FirebaseApp;
@@ -249,7 +250,7 @@ public class MainActivity extends AppCompatActivity implements AudioService.Serv
 
         tabLayout = findViewById(R.id.tabs);
         tabLayout.setupWithViewPager(pager);
-        tabLayout.setBackgroundColor(getResources().getColor(R.color.light_black));
+        tabLayout.setBackgroundColor(ContextCompat.getColor(this, R.color.light_black));
         registerListeners();
 
     }
@@ -321,9 +322,9 @@ public class MainActivity extends AppCompatActivity implements AudioService.Serv
                             tabLayout.setVisibility(View.GONE);
                         else
                         {
-                            tabLayout.setBackgroundColor(getResources().getColor(R.color.play_fragment_bars));
+                            tabLayout.setBackgroundColor(ContextCompat.getColor(this, R.color.play_fragment_bars));
                             if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                                window.setStatusBarColor(getResources().getColor(R.color.black_b));
+                                window.setStatusBarColor(ContextCompat.getColor(this, R.color.black_b));
                                 window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
                             }
 

--- a/app/src/main/java/com/stipess/youplay/SettingsActivity.java
+++ b/app/src/main/java/com/stipess/youplay/SettingsActivity.java
@@ -6,6 +6,7 @@ import android.view.MenuItem;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
+import androidx.core.content.ContextCompat;
 
 import com.stipess.youplay.Ilisteners.OnThemeChanged;
 import com.stipess.youplay.fragments.SettingsFragment;
@@ -53,7 +54,7 @@ public class SettingsActivity extends AppCompatActivity implements OnThemeChange
         SettingsFragment fragment = new SettingsFragment();
         fragment.setListener(this);
 
-        toolbar.setTitleTextColor(getResources().getColor(ThemeManager.getFontTheme()));
+        toolbar.setTitleTextColor(ContextCompat.getColor(this, ThemeManager.getFontTheme()));
 
         getSupportFragmentManager().beginTransaction()
                 .replace(R.id.content_frame, fragment)

--- a/app/src/main/java/com/stipess/youplay/adapter/PlaylistAdapter.java
+++ b/app/src/main/java/com/stipess/youplay/adapter/PlaylistAdapter.java
@@ -17,6 +17,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.RecyclerView;
+import androidx.core.content.ContextCompat;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
@@ -286,28 +287,28 @@ public class PlaylistAdapter extends RecyclerView.Adapter<PlaylistAdapter.ViewHo
             holder.title.setText(pjesma.getTitle());
             if(this.position != position)
             {
-                holder.title.setTextColor(context.getResources().getColor(R.color.suggestions));
-                holder.itemView.setBackgroundColor(context.getResources().getColor(R.color.black));
+                holder.title.setTextColor(ContextCompat.getColor(context, R.color.suggestions));
+                holder.itemView.setBackgroundColor(ContextCompat.getColor(context, R.color.black));
                 holder.title.setEllipsize(TextUtils.TruncateAt.END);
                 holder.title.setSelected(false);
                 if(pjesma.getDownloaded() == 1)
-                    holder.duration.setTextColor(context.getResources().getColor(R.color.suggestions));
+                    holder.duration.setTextColor(ContextCompat.getColor(context, R.color.suggestions));
                 else
-                    holder.duration.setTextColor(context.getResources().getColor(R.color.grey));
+                    holder.duration.setTextColor(ContextCompat.getColor(context, R.color.grey));
             }
             else
             {
-                holder.itemView.setBackgroundColor(context.getResources().getColor(R.color.lighter_black));
-                holder.title.setTextColor(context.getResources().getColor(R.color.seekbar_progress));
+                holder.itemView.setBackgroundColor(ContextCompat.getColor(context, R.color.lighter_black));
+                holder.title.setTextColor(ContextCompat.getColor(context, R.color.seekbar_progress));
                 holder.title.setEllipsize(TextUtils.TruncateAt.MARQUEE);
                 holder.title.setSelected(true);
                 holder.title.setMarqueeRepeatLimit(-1);
                 holder.title.setSingleLine(true);
-                holder.duration.setTextColor(context.getResources().getColor(R.color.seekbar_progress));
+                holder.duration.setTextColor(ContextCompat.getColor(context, R.color.seekbar_progress));
             }
 
             if(pjesma.getDownloaded() == 0 && !pjesma.equals(PlayFragment.currentlyPlayingSong))
-                holder.title.setTextColor(context.getResources().getColor(R.color.grey));
+                holder.title.setTextColor(ContextCompat.getColor(context, R.color.grey));
 
             holder.duration.setText(pjesma.getDuration());
 
@@ -375,15 +376,15 @@ public class PlaylistAdapter extends RecyclerView.Adapter<PlaylistAdapter.ViewHo
 
             if(this.position != position)
             {
-                holder.title.setTextColor(context.getResources().getColor(R.color.suggestions));
-                holder.itemView.setBackgroundColor(context.getResources().getColor(R.color.black));
-                holder.duration.setTextColor(context.getResources().getColor(R.color.suggestions));
+                holder.title.setTextColor(ContextCompat.getColor(context, R.color.suggestions));
+                holder.itemView.setBackgroundColor(ContextCompat.getColor(context, R.color.black));
+                holder.duration.setTextColor(ContextCompat.getColor(context, R.color.suggestions));
             }
             else
             {
-                holder.itemView.setBackgroundColor(context.getResources().getColor(R.color.lighter_black));
-                holder.title.setTextColor(context.getResources().getColor(R.color.seekbar_progress));
-                holder.duration.setTextColor(context.getResources().getColor(R.color.seekbar_progress));
+                holder.itemView.setBackgroundColor(ContextCompat.getColor(context, R.color.lighter_black));
+                holder.title.setTextColor(ContextCompat.getColor(context, R.color.seekbar_progress));
+                holder.duration.setTextColor(ContextCompat.getColor(context, R.color.seekbar_progress));
             }
 
             holder.itemView.setTag(station);

--- a/app/src/main/java/com/stipess/youplay/adapter/VideoAdapter.java
+++ b/app/src/main/java/com/stipess/youplay/adapter/VideoAdapter.java
@@ -15,6 +15,7 @@ import androidx.annotation.NonNull;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.RecyclerView;
+import androidx.core.content.ContextCompat;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.DecodeFormat;
@@ -249,7 +250,7 @@ public class VideoAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
                         viewHolder.info.setVisibility(View.VISIBLE);
                         viewHolder.downloaded.setVisibility(View.VISIBLE);
                         viewHolder.dragDrop.setVisibility(View.GONE);
-                        viewHolder.itemView.setBackgroundColor(context.getResources().getColor(ThemeManager.getUnselectedTheme()));
+                        viewHolder.itemView.setBackgroundColor(ContextCompat.getColor(context, ThemeManager.getUnselectedTheme()));
                     }
                     else
                     {
@@ -270,9 +271,9 @@ public class VideoAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
                         });
 
                         if(selected.contains(list))
-                            viewHolder.itemView.setBackgroundColor(context.getResources().getColor(ThemeManager.getSelectedTheme()));
+                            viewHolder.itemView.setBackgroundColor(ContextCompat.getColor(context, ThemeManager.getSelectedTheme()));
                         else
-                            viewHolder.itemView.setBackgroundColor(context.getResources().getColor(ThemeManager.getUnselectedTheme()));
+                            viewHolder.itemView.setBackgroundColor(ContextCompat.getColor(context, ThemeManager.getUnselectedTheme()));
                     }
 
                     viewHolder.info.setOnClickListener(new View.OnClickListener() {

--- a/app/src/main/java/com/stipess/youplay/fragments/BaseFragment.java
+++ b/app/src/main/java/com/stipess/youplay/fragments/BaseFragment.java
@@ -11,6 +11,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.view.View;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
@@ -36,10 +37,9 @@ public abstract class BaseFragment extends Fragment {
     }
 
     @Override
-    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
         handler = new Handler();
-        setRetainInstance(true);
     }
 
     void setPlayScreen()

--- a/app/src/main/java/com/stipess/youplay/fragments/HistoryFragment.java
+++ b/app/src/main/java/com/stipess/youplay/fragments/HistoryFragment.java
@@ -185,14 +185,8 @@ public class HistoryFragment extends BaseFragment implements OnMusicSelected,
     }
 
     @Override
-    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
-        setRetainInstance(true);
-    }
-
-
-    @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
         setupActionBar();
     }
 

--- a/app/src/main/java/com/stipess/youplay/fragments/PlayFragment.java
+++ b/app/src/main/java/com/stipess/youplay/fragments/PlayFragment.java
@@ -219,7 +219,7 @@ public class PlayFragment extends BaseFragment implements View.OnClickListener,
         AudioManager audioManager = (AudioManager) getContext().getSystemService(Context.AUDIO_SERVICE);
         int streamVolume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC);
         if(streamVolume == 0)
-            volume.setForeground(getResources().getDrawable(R.drawable.volume_mute));
+            volume.setForeground(ContextCompat.getDrawable(requireContext(), R.drawable.volume_mute));
 
         ConstraintLayout playFragment = view.findViewById(R.id.play_fragment);
         playFragment.setOnClickListener(this);
@@ -235,7 +235,7 @@ public class PlayFragment extends BaseFragment implements View.OnClickListener,
             if(audioService != null && audioPlayer.getMusicList() != null && !audioPlayer.isStream())
             {
                 if(audioPlayer.isShuffled())
-                    shuffle.setForeground(getResources().getDrawable(R.drawable.shuffle_pressed));
+                    shuffle.setForeground(ContextCompat.getDrawable(requireContext(), R.drawable.shuffle_pressed));
 
                 tempList.clear();
                 if(audioPlayer.getCurrentlyPlaying() != null)
@@ -495,9 +495,8 @@ public class PlayFragment extends BaseFragment implements View.OnClickListener,
     }
 
     @Override
-    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
-        setRetainInstance(true);
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
         db = YouPlayDatabase.getInstance();
     }
 

--- a/app/src/main/java/com/stipess/youplay/fragments/PlaylistTableFragment.java
+++ b/app/src/main/java/com/stipess/youplay/fragments/PlaylistTableFragment.java
@@ -142,9 +142,9 @@ public class PlaylistTableFragment extends BaseFragment implements OnMusicSelect
         super.onResume();
 
         if(getView() != null)
-            getView().setBackgroundColor(getResources().getColor(ThemeManager.getTheme()));
+            getView().setBackgroundColor(ContextCompat.getColor(requireContext(), ThemeManager.getTheme()));
 
-        dividerItemDecoration.setDrawable(getActivity().getResources().getDrawable(ThemeManager.getDividerColor()));
+        dividerItemDecoration.setDrawable(ContextCompat.getDrawable(requireContext(), ThemeManager.getDividerColor()));
         recyclerView.removeItemDecoration(dividerItemDecoration);
         recyclerView.addItemDecoration(dividerItemDecoration);
     }
@@ -163,14 +163,14 @@ public class PlaylistTableFragment extends BaseFragment implements OnMusicSelect
             Toast.makeText(getContext(), getString(R.string.playlist_error, title), Toast.LENGTH_SHORT).show();
         }
 
-        recyclerView.setBackgroundColor(getResources().getColor(ThemeManager.getTheme()));
-        view.setBackgroundColor(getResources().getColor(ThemeManager.getTheme()));
+        recyclerView.setBackgroundColor(ContextCompat.getColor(requireContext(), ThemeManager.getTheme()));
+        view.setBackgroundColor(ContextCompat.getColor(requireContext(), ThemeManager.getTheme()));
 
         videoAdapter = new VideoAdapter(getContext(), R.layout.play_adapter_view, data, false);
         LinearLayoutManager linearLayoutManager = new LinearLayoutManager(getActivity());
         recyclerView.setLayoutManager(linearLayoutManager);
         dividerItemDecoration = new DividerItemDecoration(recyclerView.getContext(), linearLayoutManager.getOrientation());
-        dividerItemDecoration.setDrawable(getActivity().getResources().getDrawable(ThemeManager.getDividerColor()));
+        dividerItemDecoration.setDrawable(ContextCompat.getDrawable(requireContext(), ThemeManager.getDividerColor()));
         recyclerView.addItemDecoration(dividerItemDecoration);
         recyclerView.setAdapter(videoAdapter);
         videoAdapter.setListener(this);

--- a/app/src/main/java/com/stipess/youplay/fragments/RadioFragment.java
+++ b/app/src/main/java/com/stipess/youplay/fragments/RadioFragment.java
@@ -25,6 +25,7 @@ import androidx.fragment.app.FragmentTransaction;
 import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+import androidx.core.content.ContextCompat;
 
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.snackbar.Snackbar;
@@ -140,7 +141,7 @@ public class RadioFragment extends BaseFragment implements OnRadioSelected, View
         LinearLayoutManager linearLayoutManager = new LinearLayoutManager(getActivity());
         recyclerView.setLayoutManager(linearLayoutManager);
         dividerItemDecoration = new DividerItemDecoration(recyclerView.getContext(), linearLayoutManager.getOrientation());
-        dividerItemDecoration.setDrawable(getActivity().getResources().getDrawable(ThemeManager.getDividerColor()));
+        dividerItemDecoration.setDrawable(ContextCompat.getDrawable(requireContext(), ThemeManager.getDividerColor()));
         recyclerView.addItemDecoration(dividerItemDecoration);
         recyclerView.getRecycledViewPool().clear();
         actionBar = ((AppCompatActivity)getActivity()).getSupportActionBar();
@@ -155,17 +156,12 @@ public class RadioFragment extends BaseFragment implements OnRadioSelected, View
         setupActionBar();
     }
 
-    @Override
-    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
-        setRetainInstance(true);
-    }
 
     @Override
     public void onResume() {
         super.onResume();
 
-        dividerItemDecoration.setDrawable(getActivity().getResources().getDrawable(ThemeManager.getDividerColor()));
+        dividerItemDecoration.setDrawable(ContextCompat.getDrawable(requireContext(), ThemeManager.getDividerColor()));
         recyclerView.removeItemDecoration(dividerItemDecoration);
         recyclerView.addItemDecoration(dividerItemDecoration);
 


### PR DESCRIPTION
## Summary
- modernize `getParcelableExtra` handling in `AudioService`
- migrate to `ContextCompat` for color and drawable access
- replace `onActivityCreated` with `onViewCreated` and remove `setRetainInstance`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68448656d874832cbd47635c37df004f