### PR TITLE
Fix context usage in listener

### DIFF
--- a/app/src/main/java/com/stipess/youplay/MainActivity.java
+++ b/app/src/main/java/com/stipess/youplay/MainActivity.java
@@ -322,9 +322,9 @@ public class MainActivity extends AppCompatActivity implements AudioService.Serv
                             tabLayout.setVisibility(View.GONE);
                         else
                         {
-                            tabLayout.setBackgroundColor(ContextCompat.getColor(this, R.color.play_fragment_bars));
+                            tabLayout.setBackgroundColor(ContextCompat.getColor(MainActivity.this, R.color.play_fragment_bars));
                             if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                                window.setStatusBarColor(ContextCompat.getColor(this, R.color.black_b));
+                                window.setStatusBarColor(ContextCompat.getColor(MainActivity.this, R.color.black_b));
                                 window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
                             }
 


### PR DESCRIPTION
## Summary
- ensure `ContextCompat.getColor` is passed the `MainActivity` context inside the `ViewPager` page change listener

## Testing
- `./gradlew test -q` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684488847684832caa71fc8c077df758