### PR TITLE
Refactor deprecated Android APIs

### DIFF
--- a/app/src/main/java/com/stipess/youplay/AudioService.java
+++ b/app/src/main/java/com/stipess/youplay/AudioService.java
@@ -243,8 +243,12 @@ public class AudioService extends Service implements AudioManager.OnAudioFocusCh
 
         registerReceiver(outputListener, new IntentFilter(AudioManager.ACTION_AUDIO_BECOMING_NOISY));
         if (connectivityManager != null) {
-            NetworkRequest req = new NetworkRequest.Builder().build();
-            connectivityManager.registerNetworkCallback(req, networkStateCallback);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                connectivityManager.registerDefaultNetworkCallback(networkStateCallback);
+            } else {
+                NetworkRequest req = new NetworkRequest.Builder().build();
+                connectivityManager.registerNetworkCallback(req, networkStateCallback);
+            }
         }
 
         startForegroundService();

--- a/app/src/main/java/com/stipess/youplay/MainActivity.java
+++ b/app/src/main/java/com/stipess/youplay/MainActivity.java
@@ -325,7 +325,14 @@ public class MainActivity extends AppCompatActivity implements AudioService.Serv
                             tabLayout.setBackgroundColor(ContextCompat.getColor(MainActivity.this, R.color.play_fragment_bars));
                             if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                                 window.setStatusBarColor(ContextCompat.getColor(MainActivity.this, R.color.black_b));
-                                window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
+                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                                    WindowInsetsController controller = window.getInsetsController();
+                                    if (controller != null) {
+                                        controller.setSystemBarsAppearance(0, WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS);
+                                    }
+                                } else {
+                                    window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
+                                }
                             }
 
                             tabLayout.getTabAt(position).setIcon(R.drawable.music_pressed);
@@ -337,13 +344,21 @@ public class MainActivity extends AppCompatActivity implements AudioService.Serv
                         break;
                     case 1:
                         tabLayout.setVisibility(View.VISIBLE);
-                        tabLayout.setBackgroundColor(getResources().getColor(ThemeManager.getTheme()));
+                        tabLayout.setBackgroundColor(ContextCompat.getColor(MainActivity.this, ThemeManager.getTheme()));
                         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                             if(pre)
-                                window.setStatusBarColor(getResources().getColor(R.color.toolbar_color));
+                                window.setStatusBarColor(ContextCompat.getColor(MainActivity.this, R.color.toolbar_color));
                             else{
-                                window.setStatusBarColor(getResources().getColor(R.color.adapter_color));
-                                window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+                                window.setStatusBarColor(ContextCompat.getColor(MainActivity.this, R.color.adapter_color));
+                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                                    WindowInsetsController controller = window.getInsetsController();
+                                    if (controller != null) {
+                                        controller.setSystemBarsAppearance(WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS,
+                                                WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS);
+                                    }
+                                } else {
+                                    window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+                                }
                             }
                         }
 
@@ -356,13 +371,21 @@ public class MainActivity extends AppCompatActivity implements AudioService.Serv
                         break;
                     case 2:
                         tabLayout.setVisibility(View.VISIBLE);
-                        tabLayout.setBackgroundColor(getResources().getColor(ThemeManager.getTheme()));
+                        tabLayout.setBackgroundColor(ContextCompat.getColor(MainActivity.this, ThemeManager.getTheme()));
                         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                             if(pre)
-                                window.setStatusBarColor(getResources().getColor(R.color.toolbar_color));
+                                window.setStatusBarColor(ContextCompat.getColor(MainActivity.this, R.color.toolbar_color));
                             else{
-                                window.setStatusBarColor(getResources().getColor(R.color.adapter_color));
-                                window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+                                window.setStatusBarColor(ContextCompat.getColor(MainActivity.this, R.color.adapter_color));
+                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                                    WindowInsetsController controller = window.getInsetsController();
+                                    if (controller != null) {
+                                        controller.setSystemBarsAppearance(WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS,
+                                                WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS);
+                                    }
+                                } else {
+                                    window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+                                }
                             }
                         }
 
@@ -374,13 +397,21 @@ public class MainActivity extends AppCompatActivity implements AudioService.Serv
                         break;
                     case 3:
                         tabLayout.setVisibility(View.VISIBLE);
-                        tabLayout.setBackgroundColor(getResources().getColor(ThemeManager.getTheme()));
+                        tabLayout.setBackgroundColor(ContextCompat.getColor(MainActivity.this, ThemeManager.getTheme()));
                         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                             if(pre)
-                                window.setStatusBarColor(getResources().getColor(R.color.toolbar_color));
+                                window.setStatusBarColor(ContextCompat.getColor(MainActivity.this, R.color.toolbar_color));
                             else{
-                                window.setStatusBarColor(getResources().getColor(R.color.adapter_color));
-                                window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+                                window.setStatusBarColor(ContextCompat.getColor(MainActivity.this, R.color.adapter_color));
+                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                                    WindowInsetsController controller = window.getInsetsController();
+                                    if (controller != null) {
+                                        controller.setSystemBarsAppearance(WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS,
+                                                WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS);
+                                    }
+                                } else {
+                                    window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+                                }
                             }
                         }
 
@@ -393,13 +424,21 @@ public class MainActivity extends AppCompatActivity implements AudioService.Serv
                         break;
                     case 4:
                         tabLayout.setVisibility(View.VISIBLE);
-                        tabLayout.setBackgroundColor(getResources().getColor(ThemeManager.getTheme()));
+                        tabLayout.setBackgroundColor(ContextCompat.getColor(MainActivity.this, ThemeManager.getTheme()));
                         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                             if(pre)
-                                window.setStatusBarColor(getResources().getColor(R.color.play_fragment_bars));
+                                window.setStatusBarColor(ContextCompat.getColor(MainActivity.this, R.color.play_fragment_bars));
                             else {
-                                window.setStatusBarColor(getResources().getColor(R.color.white));
-                                window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+                                window.setStatusBarColor(ContextCompat.getColor(MainActivity.this, R.color.white));
+                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                                    WindowInsetsController controller = window.getInsetsController();
+                                    if (controller != null) {
+                                        controller.setSystemBarsAppearance(WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS,
+                                                WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS);
+                                    }
+                                } else {
+                                    window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+                                }
                             }
                         }
 
@@ -935,7 +974,7 @@ public class MainActivity extends AppCompatActivity implements AudioService.Serv
             searchFragment.refreshFragment();
             radioFragment.setupActionBar();
             radioFragment.refreshFragment();
-            tabLayout.setBackgroundColor(getResources().getColor(ThemeManager.getTheme()));
+            tabLayout.setBackgroundColor(ContextCompat.getColor(this, ThemeManager.getTheme()));
         }
 
     }

--- a/app/src/main/java/com/stipess/youplay/fragments/HistoryFragment.java
+++ b/app/src/main/java/com/stipess/youplay/fragments/HistoryFragment.java
@@ -133,9 +133,9 @@ public class HistoryFragment extends BaseFragment implements OnMusicSelected,
         history      = view.findViewById(R.id.empty_history);
         ConstraintLayout layout = view.findViewById(R.id.history_container);
 
-        layout.setBackgroundColor(getResources().getColor(ThemeManager.getTheme()));
+        layout.setBackgroundColor(ContextCompat.getColor(requireContext(), ThemeManager.getTheme()));
 
-        recyclerView.setBackgroundColor(getResources().getColor(ThemeManager.getTheme()));
+        recyclerView.setBackgroundColor(ContextCompat.getColor(requireContext(), ThemeManager.getTheme()));
 
         addToPlaylist.setOnClickListener(this);
         addToQ.setOnClickListener(this);
@@ -546,7 +546,7 @@ public class HistoryFragment extends BaseFragment implements OnMusicSelected,
 
     private void checkIfEmpty()
     {
-        history.setTextColor(getResources().getColor(ThemeManager.getFontTheme()));
+        history.setTextColor(ContextCompat.getColor(requireContext(), ThemeManager.getFontTheme()));
         if(musicList.size() > 0)
             history.setVisibility(View.GONE);
         else

--- a/app/src/main/java/com/stipess/youplay/fragments/PlayFragment.java
+++ b/app/src/main/java/com/stipess/youplay/fragments/PlayFragment.java
@@ -982,7 +982,7 @@ public class PlayFragment extends BaseFragment implements View.OnClickListener,
     {
         if(!audioPlayer.isAutoplay())
         {
-            autoPlay.setTextColor(getResources().getColor(R.color.seekbar_progress));
+            autoPlay.setTextColor(ContextCompat.getColor(requireContext(), R.color.seekbar_progress));
             audioPlayer.setAutoplay(true);
             if(mediaCompleted) {
                 audioService.getAudioPlayer().nextSong();
@@ -991,7 +991,7 @@ public class PlayFragment extends BaseFragment implements View.OnClickListener,
         }
         else
         {
-            autoPlay.setTextColor(getResources().getColor(R.color.suggestions));
+            autoPlay.setTextColor(ContextCompat.getColor(requireContext(), R.color.suggestions));
             audioPlayer.setAutoplay(false);
         }
 

--- a/app/src/main/java/com/stipess/youplay/fragments/PlaylistFragment.java
+++ b/app/src/main/java/com/stipess/youplay/fragments/PlaylistFragment.java
@@ -116,7 +116,7 @@ public class PlaylistFragment extends BaseFragment implements OnPlaylistSelected
         recyclerView.removeItemDecoration(dividerItemDecoration);
         recyclerView.addItemDecoration(dividerItemDecoration);
         if(getView() != null)
-            getView().setBackgroundColor(getResources().getColor(ThemeManager.getTheme()));
+            getView().setBackgroundColor(ContextCompat.getColor(requireContext(), ThemeManager.getTheme()));
 
         if(EasyPermissions.hasPermissions(getContext(), MainActivity.PERMISSIONS) && playlists.isEmpty())
         {

--- a/app/src/main/java/com/stipess/youplay/fragments/SearchFragment.java
+++ b/app/src/main/java/com/stipess/youplay/fragments/SearchFragment.java
@@ -143,7 +143,7 @@ public class SearchFragment extends BaseFragment implements OnMusicSelected, OnS
         videoAdapter.setListener(this);
         LinearLayoutManager linearLayoutManager = new LinearLayoutManager(getActivity());
         recyclerView.setLayoutManager(linearLayoutManager);
-        dividerItemDecoration = new SeparatorDecoration(getResources().getColor(ThemeManager.getDividerColorSearch()), 2);
+        dividerItemDecoration = new SeparatorDecoration(ContextCompat.getColor(requireContext(), ThemeManager.getDividerColorSearch()), 2);
 
         SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(getContext());
         Set <String> set = settings.getStringSet(SEARCH_LIST, new HashSet<>());
@@ -458,8 +458,8 @@ public class SearchFragment extends BaseFragment implements OnMusicSelected, OnS
             if(ThemeManager.getDebug().equals("Dark"))
             {
                 EditText searchEditText = searchView.findViewById(androidx.appcompat.R.id.search_src_text);
-                searchEditText.setTextColor(getResources().getColor(R.color.white));
-                searchEditText.setHintTextColor(getResources().getColor(R.color.white));
+                searchEditText.setTextColor(ContextCompat.getColor(requireContext(), R.color.white));
+                searchEditText.setHintTextColor(ContextCompat.getColor(requireContext(), R.color.white));
             }
         }
     }

--- a/app/src/main/java/com/stipess/youplay/fragments/SettingsFragment.java
+++ b/app/src/main/java/com/stipess/youplay/fragments/SettingsFragment.java
@@ -96,11 +96,26 @@ public class SettingsFragment extends PreferenceFragmentCompat {
 
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             if(pre) {
-                window.setStatusBarColor(getResources().getColor(R.color.toolbar_color));
-                window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
+                window.setStatusBarColor(ContextCompat.getColor(requireContext(), R.color.toolbar_color));
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    WindowInsetsController controller = window.getInsetsController();
+                    if (controller != null) {
+                        controller.setSystemBarsAppearance(0, WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS);
+                    }
+                } else {
+                    window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
+                }
             } else{
-                window.setStatusBarColor(getResources().getColor(R.color.adapter_color));
-                window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+                window.setStatusBarColor(ContextCompat.getColor(requireContext(), R.color.adapter_color));
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    WindowInsetsController controller = window.getInsetsController();
+                    if (controller != null) {
+                        controller.setSystemBarsAppearance(WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS,
+                                WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS);
+                    }
+                } else {
+                    window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+                }
             }
         }
 

--- a/app/src/main/java/com/stipess/youplay/music/Music.java
+++ b/app/src/main/java/com/stipess/youplay/music/Music.java
@@ -167,7 +167,11 @@ public class Music implements Parcelable {
         duration = in.readString();
         id = in.readString();
         views = in.readString();
-        image = in.readParcelable(Bitmap.class.getClassLoader());
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            image = in.readParcelable(Bitmap.class.getClassLoader(), Bitmap.class);
+        } else {
+            image = in.readParcelable(Bitmap.class.getClassLoader());
+        }
         url = in.readString();
         path = in.readString();
         downloaded = in.readInt();


### PR DESCRIPTION
## Summary
- use `registerDefaultNetworkCallback` when possible
- apply typed `getParcelableExtra` and `readParcelable`
- switch to `ContextCompat.getColor` and `WindowInsetsController`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6844899fee08832ca54acf8a53444e71