### PR TITLE
Fix missing imports in Android modules

### DIFF
--- a/app/src/main/java/com/stipess/youplay/MainActivity.java
+++ b/app/src/main/java/com/stipess/youplay/MainActivity.java
@@ -26,6 +26,7 @@ import android.view.KeyEvent;
 import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
+import android.view.WindowInsetsController;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Toast;
 

--- a/app/src/main/java/com/stipess/youplay/fragments/SearchFragment.java
+++ b/app/src/main/java/com/stipess/youplay/fragments/SearchFragment.java
@@ -15,6 +15,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Build;
 import androidx.preference.PreferenceManager;
+import androidx.core.content.ContextCompat;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;

--- a/app/src/main/java/com/stipess/youplay/fragments/SettingsFragment.java
+++ b/app/src/main/java/com/stipess/youplay/fragments/SettingsFragment.java
@@ -12,6 +12,8 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import androidx.preference.PreferenceManager;
+import androidx.core.content.ContextCompat;
+import android.view.WindowInsetsController;
 import android.util.Log;
 import android.view.View;
 import android.view.Window;

--- a/app/src/main/java/com/stipess/youplay/music/Music.java
+++ b/app/src/main/java/com/stipess/youplay/music/Music.java
@@ -2,6 +2,7 @@ package com.stipess.youplay.music;
 
 import android.graphics.Bitmap;
 
+import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
 


### PR DESCRIPTION
## Summary
- add missing android.os.Build import in Music.java
- add WindowInsetsController import for MainActivity and SettingsFragment
- add ContextCompat import for SearchFragment and SettingsFragment

## Testing
- `./gradlew assembleDebug` *(fails: Unable to download dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68448c60b630832cb7819676b3a527f4