### PR TITLE
Fix FragmentStateAdapter import

### DIFF
--- a/app/src/main/java/com/stipess/youplay/MainActivity.java
+++ b/app/src/main/java/com/stipess/youplay/MainActivity.java
@@ -39,7 +39,7 @@ import androidx.core.content.FileProvider;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentActivity;
-import androidx.fragment.app.FragmentStateAdapter;
+import androidx.viewpager2.adapter.FragmentStateAdapter;
 import androidx.activity.OnBackPressedCallback;
 import androidx.viewpager2.widget.ViewPager2;
 import androidx.core.content.ContextCompat;


### PR DESCRIPTION
## Summary
- use the correct FragmentStateAdapter package for ViewPager2

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68448f546d28832c943b1c4e4662b239