### PR TITLE
Replace deprecated Android APIs

### DIFF
--- a/app/src/main/java/com/stipess/youplay/adapter/PlaylistAdapter.java
+++ b/app/src/main/java/com/stipess/youplay/adapter/PlaylistAdapter.java
@@ -170,7 +170,7 @@ public class PlaylistAdapter extends RecyclerView.Adapter<PlaylistAdapter.ViewHo
                 if(play == ListType.PLAYLIST_TABLE && isEdit) {
                     return makeMovementFlags(ItemTouchHelper.DOWN | ItemTouchHelper.UP, 0);
                 }
-                if(viewHolder.getAdapterPosition() == position || play == ListType.STATIONS || play == ListType.PLAYLIST_TABLE)
+                if(viewHolder.getBindingAdapterPosition() == position || play == ListType.STATIONS || play == ListType.PLAYLIST_TABLE)
                     return makeMovementFlags(0,0);
                 return makeMovementFlags(0,
                         ItemTouchHelper.RIGHT);
@@ -180,17 +180,17 @@ public class PlaylistAdapter extends RecyclerView.Adapter<PlaylistAdapter.ViewHo
             public boolean onMove(@NonNull RecyclerView recyclerView, @NonNull RecyclerView.ViewHolder viewHolder, @NonNull RecyclerView.ViewHolder target) {
                 if(play == ListType.PLAYLIST_TABLE) {
                     moved = true;
-                    int adapterPos = viewHolder.getAdapterPosition();
-                    int targetPos = target.getAdapterPosition();
+                    int adapterPos = viewHolder.getBindingAdapterPosition();
+                    int targetPos = target.getBindingAdapterPosition();
                     if(playlists.size() > 1)
                     {
-                        Collections.swap(playlists, viewHolder.getAdapterPosition(), target.getAdapterPosition());
-                        adapterPos = viewHolder.getAdapterPosition();
-                        targetPos = target.getAdapterPosition();
+                        Collections.swap(playlists, viewHolder.getBindingAdapterPosition(), target.getBindingAdapterPosition());
+                        adapterPos = viewHolder.getBindingAdapterPosition();
+                        targetPos = target.getBindingAdapterPosition();
                     }
 
 
-                    notifyItemMoved(viewHolder.getAdapterPosition(), target.getAdapterPosition());
+                    notifyItemMoved(viewHolder.getBindingAdapterPosition(), target.getBindingAdapterPosition());
 
                    SQLiteDatabase db  = youPlayDatabase.getDatabase(YouPlayDatabase.PLAYLIST_DB);
 
@@ -221,7 +221,7 @@ public class PlaylistAdapter extends RecyclerView.Adapter<PlaylistAdapter.ViewHo
 
             @Override
             public void onSwiped(@NonNull RecyclerView.ViewHolder viewHolder, int i) {
-                int adapterPos = viewHolder.getAdapterPosition();
+                int adapterPos = viewHolder.getBindingAdapterPosition();
                 if(play != ListType.STATIONS)
                 {
                     list.remove(adapterPos);

--- a/app/src/main/java/com/stipess/youplay/adapter/SearchAdapter.java
+++ b/app/src/main/java/com/stipess/youplay/adapter/SearchAdapter.java
@@ -113,7 +113,7 @@ public class SearchAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
                 @Override
                 public void onClick(View view) {
                     if (listener != null) {
-                        listener.onInfoClicked(holder.getAdapterPosition(), view);
+                        listener.onInfoClicked(holder.getBindingAdapterPosition(), view);
                     }
                 }
             });

--- a/app/src/main/java/com/stipess/youplay/adapter/VideoAdapter.java
+++ b/app/src/main/java/com/stipess/youplay/adapter/VideoAdapter.java
@@ -109,22 +109,22 @@ public class VideoAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
             @Override
             public boolean onMove(RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder, RecyclerView.ViewHolder target) {
 
-                if(viewHolder.getItemViewType() != target.getItemViewType() || viewHolder.getAdapterPosition() == 0)
+    if(viewHolder.getItemViewType() != target.getItemViewType() || viewHolder.getBindingAdapterPosition() == 0)
                     return false;
 
                 moved = true;
-                int adapterPos = viewHolder.getAdapterPosition();
-                int targetPos = target.getAdapterPosition();
+    int adapterPos = viewHolder.getBindingAdapterPosition();
+    int targetPos = target.getBindingAdapterPosition();
                 if(data.size() > 1)
                 {
-                    Collections.swap(data, viewHolder.getAdapterPosition()-1, target.getAdapterPosition()-1);
-                    adapterPos = viewHolder.getAdapterPosition()-1;
-                    targetPos = target.getAdapterPosition()-1;
+        Collections.swap(data, viewHolder.getBindingAdapterPosition()-1, target.getBindingAdapterPosition()-1);
+        adapterPos = viewHolder.getBindingAdapterPosition()-1;
+        targetPos = target.getBindingAdapterPosition()-1;
                 }
                 else
-                    Collections.swap(data, viewHolder.getAdapterPosition(), target.getAdapterPosition());
+        Collections.swap(data, viewHolder.getBindingAdapterPosition(), target.getBindingAdapterPosition());
 
-                notifyItemMoved(viewHolder.getAdapterPosition(), target.getAdapterPosition());
+    notifyItemMoved(viewHolder.getBindingAdapterPosition(), target.getBindingAdapterPosition());
 
                 SQLiteDatabase db;
                 if(tableName.equals(Constants.TABLE_NAME) && history)


### PR DESCRIPTION
## Summary
- replace deprecated `setOnScrollListener` with `addOnScrollListener`
- switch all `getAdapterPosition()` calls to `getBindingAdapterPosition()`
- update network connection checks to use `NetworkCallback` when possible

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6844917b46bc832c9c75993b4ba4d420