### PR TITLE
Fix transition deprecation in SettingsActivity

### DIFF
--- a/app/src/main/java/com/stipess/youplay/SettingsActivity.java
+++ b/app/src/main/java/com/stipess/youplay/SettingsActivity.java
@@ -69,9 +69,8 @@ public class SettingsActivity extends AppCompatActivity implements OnThemeChange
         else
             setTheme(R.style.LightTheme);
 
-        finish();
         startActivity(getIntent());
-        overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
+        finish();
     }
 
     @Override

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -15,6 +15,9 @@
         <item name="tabLayout">@color/adapter_color</item>
         <item name="android:textColor">@color/play_fragment_bars</item>
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
+        <item name="android:windowActivityTransitions">true</item>
+        <item name="android:windowEnterTransition">@android:transition/fade</item>
+        <item name="android:windowExitTransition">@android:transition/fade</item>
     </style>
 
     <style name="BlackTheme" parent="Theme.AppCompat.NoActionBar">
@@ -64,6 +67,9 @@
         <item name="colorAccent">@color/downloaded</item>
         <item name="android:textColor">@color/white</item>
         <item name="alertDialogTheme">@style/DialogDark</item>
+        <item name="android:windowActivityTransitions">true</item>
+        <item name="android:windowEnterTransition">@android:transition/fade</item>
+        <item name="android:windowExitTransition">@android:transition/fade</item>
     </style>
 
     <style name="SelectableItemTheme">


### PR DESCRIPTION
## Summary
- enable activity enter/exit fades in the app themes
- remove deprecated `overridePendingTransition` usage in `SettingsActivity`

## Testing
- `./gradlew test --console=plain` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6844938908ac832cafea0c59e129ca0d