### PR TITLE
Replace deprecated Handler usage

### DIFF
--- a/app/src/main/java/com/stipess/youplay/fragments/BaseFragment.java
+++ b/app/src/main/java/com/stipess/youplay/fragments/BaseFragment.java
@@ -9,6 +9,8 @@ import android.net.NetworkInfo;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
+import androidx.core.os.HandlerCompat;
 import android.view.View;
 
 import java.util.concurrent.CountDownLatch;
@@ -43,7 +45,7 @@ public abstract class BaseFragment extends Fragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        handler = new Handler();
+        handler = HandlerCompat.createAsync(Looper.getMainLooper());
     }
 
     void setPlayScreen()

--- a/app/src/main/java/com/stipess/youplay/fragments/PlayFragment.java
+++ b/app/src/main/java/com/stipess/youplay/fragments/PlayFragment.java
@@ -12,6 +12,8 @@ import android.media.AudioManager;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
+import android.os.Looper;
+import androidx.core.os.HandlerCompat;
 import androidx.preference.PreferenceManager;
 
 import androidx.annotation.NonNull;
@@ -190,7 +192,7 @@ public class PlayFragment extends BaseFragment implements View.OnClickListener,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
         View view = inflater.inflate(R.layout.fragment_play, container, false);
-        handler = new Handler();
+        handler = HandlerCompat.createAsync(Looper.getMainLooper());
         play_pause = view.findViewById(R.id.play_pause_layout);
         play_pause.setOnClickListener(this);
         FrameLayout next = view.findViewById(R.id.you_next);

--- a/app/src/main/java/com/stipess/youplay/fragments/PlaylistFragment.java
+++ b/app/src/main/java/com/stipess/youplay/fragments/PlaylistFragment.java
@@ -6,6 +6,8 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
+import androidx.core.os.HandlerCompat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -163,7 +165,7 @@ public class PlaylistFragment extends BaseFragment implements OnPlaylistSelected
 
             playlistTitle.requestFocus();
             // bez delay nezeli radit.
-            new Handler().postDelayed(new Runnable() {
+            playlistTitle.postDelayed(new Runnable() {
                 @Override
                 public void run() {
                     imm.showSoftInput(playlistTitle, InputMethodManager.SHOW_IMPLICIT);
@@ -296,7 +298,7 @@ public class PlaylistFragment extends BaseFragment implements OnPlaylistSelected
         playlistTableFragment = new PlaylistTableFragment();
         playlistTableFragment.setData(title);
 
-        Handler handler = new Handler();
+        Handler handler = HandlerCompat.createAsync(Looper.getMainLooper());
         Runnable runnable = new Runnable() {
             @Override
             public void run() {

--- a/app/src/main/java/com/stipess/youplay/fragments/SettingsFragment.java
+++ b/app/src/main/java/com/stipess/youplay/fragments/SettingsFragment.java
@@ -10,6 +10,8 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
+import androidx.core.os.HandlerCompat;
 import androidx.preference.PreferenceManager;
 import androidx.core.content.ContextCompat;
 import androidx.core.view.WindowCompat;
@@ -182,7 +184,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
                     else
                         ThemeManager.setTheme(ThemeManager.Theme.LIGHT_THEME);
 
-                    Handler handler = new Handler();
+                    Handler handler = HandlerCompat.createAsync(Looper.getMainLooper());
                     Runnable runnable = new Runnable() {
                         @Override
                         public void run() {


### PR DESCRIPTION
## Summary
- avoid `new Handler()` with no Looper
- use `HandlerCompat.createAsync(Looper.getMainLooper())`
- use `postDelayed` directly on `playlistTitle`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68449c0457a0832ca614bfff5ec9bdbb