### PR TITLE
Fix deprecated loader manager usage

### DIFF
--- a/app/src/main/java/com/stipess/youplay/fragments/PlayFragment.java
+++ b/app/src/main/java/com/stipess/youplay/fragments/PlayFragment.java
@@ -363,7 +363,8 @@ public class PlayFragment extends BaseFragment implements View.OnClickListener,
         });
         String url = Constants.YOUTUBELINK+audioPlayer.getCurrentlyPlaying().getId();
         CommentsLoader commentsLoader = new CommentsLoader(getContext(), url, page, true);
-        getLoaderManager().restartLoader(77, null, new LoaderManager.LoaderCallbacks<List<CommentsInfoItem>>() {
+        LoaderManager lm = LoaderManager.getInstance(this);
+        lm.restartLoader(77, null, new LoaderManager.LoaderCallbacks<List<CommentsInfoItem>>() {
             @NonNull
             @Override
             public Loader<List<CommentsInfoItem>> onCreateLoader(int id, @Nullable Bundle args) {
@@ -849,7 +850,8 @@ public class PlayFragment extends BaseFragment implements View.OnClickListener,
             String url = Constants.YOUTUBELINK+audioPlayer.getCurrentlyPlaying().getId();
             suggestionBar.setVisibility(View.VISIBLE);
             CommentsLoader commentsLoader = new CommentsLoader(context, url);
-            getLoaderManager().restartLoader(77, null, new LoaderManager.LoaderCallbacks<List<CommentsInfoItem>>() {
+            LoaderManager lm = LoaderManager.getInstance(PlayFragment.this);
+            lm.restartLoader(77, null, new LoaderManager.LoaderCallbacks<List<CommentsInfoItem>>() {
                 @NonNull
                 @Override
                 public Loader<List<CommentsInfoItem>> onCreateLoader(int id, @Nullable Bundle args) {

--- a/app/src/main/java/com/stipess/youplay/fragments/SearchFragment.java
+++ b/app/src/main/java/com/stipess/youplay/fragments/SearchFragment.java
@@ -226,7 +226,8 @@ public class SearchFragment extends BaseFragment implements OnMusicSelected, OnS
                     YoutubeMusicLoader ytLoader = new YoutubeMusicLoader(getContext(), query, audioService.getAudioPlayer().getSearchList());
                     if(audioService == null)
                         initAudioService();
-                    getLoaderManager().restartLoader(1, null, new LoaderManager.LoaderCallbacks<List<Music>>() {
+                    LoaderManager lm = LoaderManager.getInstance(SearchFragment.this);
+                    lm.restartLoader(1, null, new LoaderManager.LoaderCallbacks<List<Music>>() {
 
                         @Override
                         public Loader<List<Music>> onCreateLoader(int id, Bundle args) {
@@ -291,7 +292,7 @@ public class SearchFragment extends BaseFragment implements OnMusicSelected, OnS
                             swapAdapter = true;
                         }
 
-                        getActivity().getSupportLoaderManager().restartLoader(5, null, new LoaderManager.LoaderCallbacks<List<String>>() {
+                        LoaderManager.getInstance(requireActivity()).restartLoader(5, null, new LoaderManager.LoaderCallbacks<List<String>>() {
 
                             @Override
                             public Loader<List<String>> onCreateLoader(int id, Bundle args) {
@@ -353,7 +354,8 @@ public class SearchFragment extends BaseFragment implements OnMusicSelected, OnS
             initAudioService();
 
 //        loadMore.setVisibility(View.VISIBLE);
-        getLoaderManager().restartLoader(1, null, new LoaderManager.LoaderCallbacks<List<Music>>() {
+        LoaderManager lm = LoaderManager.getInstance(this);
+        lm.restartLoader(1, null, new LoaderManager.LoaderCallbacks<List<Music>>() {
 
             @Override
             public Loader<List<Music>> onCreateLoader(int id, Bundle args) {


### PR DESCRIPTION
## Summary
- replace deprecated `getLoaderManager()` calls with `LoaderManager.getInstance`
- update suggestion loading to use activity-scoped `LoaderManager`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68449e2fe6e8832cbf877d700d95b740