### PR TITLE
Replace deprecated network check

### DIFF
--- a/app/src/main/java/com/stipess/youplay/MainActivity.java
+++ b/app/src/main/java/com/stipess/youplay/MainActivity.java
@@ -11,16 +11,9 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
-import android.net.ConnectivityManager;
-import android.net.Network;
-import android.net.NetworkCapabilities;
-import android.net.NetworkInfo;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import android.os.IBinder;
 import android.os.StrictMode;
 import androidx.preference.PreferenceManager;
@@ -69,6 +62,7 @@ import com.stipess.youplay.radio.Station;
 import com.stipess.youplay.utils.FileManager;
 import com.stipess.youplay.utils.ThemeManager;
 import com.stipess.youplay.utils.Utils;
+import com.stipess.youplay.utils.NetworkUtils;
 import com.stipess.youplay.web.YouPlayWeb;
 import com.liulishuo.filedownloader.BaseDownloadTask;
 import com.liulishuo.filedownloader.FileDownloadListener;
@@ -708,43 +702,7 @@ public class MainActivity extends AppCompatActivity implements AudioService.Serv
     }
 
     private boolean internetConnection() {
-        ConnectivityManager connectivityManager
-                = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
-        if(connectivityManager == null) return false;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            final AtomicBoolean connected = new AtomicBoolean(false);
-            final CountDownLatch latch = new CountDownLatch(1);
-            ConnectivityManager.NetworkCallback callback = new ConnectivityManager.NetworkCallback() {
-                @Override
-                public void onAvailable(@NonNull Network network) {
-                    connected.set(true);
-                    latch.countDown();
-                }
-
-                @Override
-                public void onUnavailable() {
-                    connected.set(false);
-                    latch.countDown();
-                }
-            };
-            connectivityManager.registerDefaultNetworkCallback(callback);
-            try {
-                latch.await(100, TimeUnit.MILLISECONDS);
-            } catch (InterruptedException ignored) {}
-            connectivityManager.unregisterNetworkCallback(callback);
-            return connected.get();
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            Network network = connectivityManager.getActiveNetwork();
-            if (network == null) return false;
-            NetworkCapabilities caps = connectivityManager.getNetworkCapabilities(network);
-            return caps != null && (caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
-                    || caps.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)
-                    || caps.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)
-                    || caps.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH));
-        } else {
-            NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
-            return activeNetworkInfo != null && activeNetworkInfo.isConnected();
-        }
+        return NetworkUtils.hasInternet(this);
     }
 
     private void putCurrentIcon() {

--- a/app/src/main/java/com/stipess/youplay/fragments/BaseFragment.java
+++ b/app/src/main/java/com/stipess/youplay/fragments/BaseFragment.java
@@ -2,10 +2,6 @@ package com.stipess.youplay.fragments;
 
 import android.app.Activity;
 import android.content.Context;
-import android.net.ConnectivityManager;
-import android.net.Network;
-import android.net.NetworkCapabilities;
-import android.net.NetworkInfo;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -13,9 +9,7 @@ import android.os.Looper;
 import androidx.core.os.HandlerCompat;
 import android.view.View;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
+import com.stipess.youplay.utils.NetworkUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -59,44 +53,7 @@ public abstract class BaseFragment extends Fragment {
     }
 
     public boolean internetConnection() {
-        ConnectivityManager connectivityManager =
-                (ConnectivityManager) getActivity().getSystemService(Context.CONNECTIVITY_SERVICE);
-        if (connectivityManager == null) return false;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            final AtomicBoolean connected = new AtomicBoolean(false);
-            final CountDownLatch latch = new CountDownLatch(1);
-            ConnectivityManager.NetworkCallback callback = new ConnectivityManager.NetworkCallback() {
-                @Override
-                public void onAvailable(@NonNull Network network) {
-                    connected.set(true);
-                    latch.countDown();
-                }
-
-                @Override
-                public void onUnavailable() {
-                    connected.set(false);
-                    latch.countDown();
-                }
-            };
-            connectivityManager.registerDefaultNetworkCallback(callback);
-            try {
-                latch.await(100, TimeUnit.MILLISECONDS);
-            } catch (InterruptedException ignored) {}
-            connectivityManager.unregisterNetworkCallback(callback);
-            return connected.get();
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            Network network = connectivityManager.getActiveNetwork();
-            if (network == null) return false;
-            NetworkCapabilities caps = connectivityManager.getNetworkCapabilities(network);
-            return caps != null &&
-                    (caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
-                            || caps.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)
-                            || caps.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)
-                            || caps.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH));
-        } else {
-            NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
-            return activeNetworkInfo != null && activeNetworkInfo.isConnected();
-        }
+        return NetworkUtils.hasInternet(requireContext());
     }
 
     public abstract void buildAlertDialog(int position, View view);

--- a/app/src/main/java/com/stipess/youplay/fragments/SearchFragment.java
+++ b/app/src/main/java/com/stipess/youplay/fragments/SearchFragment.java
@@ -7,10 +7,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.net.ConnectivityManager;
-import android.net.Network;
-import android.net.NetworkCapabilities;
-import android.net.NetworkInfo;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Build;
@@ -69,9 +65,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
+import com.stipess.youplay.utils.NetworkUtils;
 
 import static com.stipess.youplay.utils.Constants.*;
 
@@ -484,64 +478,13 @@ public class SearchFragment extends BaseFragment implements OnMusicSelected, OnS
     }
 
     public boolean ifInternetConnection() {
-        if(getActivity() != null)
-        {
-            ConnectivityManager connectivityManager
-                    = (ConnectivityManager) getActivity().getSystemService(Context.CONNECTIVITY_SERVICE);
-            if(connectivityManager != null) {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                    final AtomicBoolean connected = new AtomicBoolean(false);
-                    final CountDownLatch latch = new CountDownLatch(1);
-                    ConnectivityManager.NetworkCallback callback = new ConnectivityManager.NetworkCallback() {
-                        @Override
-                        public void onAvailable(@NonNull Network network) {
-                            connected.set(true);
-                            latch.countDown();
-                        }
-
-                        @Override
-                        public void onUnavailable() {
-                            connected.set(false);
-                            latch.countDown();
-                        }
-                    };
-                    connectivityManager.registerDefaultNetworkCallback(callback);
-                    try {
-                        latch.await(100, TimeUnit.MILLISECONDS);
-                    } catch (InterruptedException ignored) {}
-                    connectivityManager.unregisterNetworkCallback(callback);
-                    if (connected.get()) {
-                        animate(internet);
-                        internet.setVisibility(View.GONE);
-                        return true;
-                    }
-                } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    Network network = connectivityManager.getActiveNetwork();
-                    if (network != null) {
-                        NetworkCapabilities caps = connectivityManager.getNetworkCapabilities(network);
-                        boolean connected = caps != null &&
-                                (caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
-                                        || caps.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)
-                                        || caps.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)
-                                        || caps.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH));
-                        if (connected) {
-                            animate(internet);
-                            internet.setVisibility(View.GONE);
-                            return true;
-                        }
-                    }
-                } else {
-                    NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
-                    if(activeNetworkInfo != null && activeNetworkInfo.isConnected())
-                    {
-                        animate(internet);
-                        internet.setVisibility(View.GONE);
-                        return true;
-                    }
-                }
+        if (getActivity() != null) {
+            if (NetworkUtils.hasInternet(requireContext())) {
+                animate(internet);
+                internet.setVisibility(View.GONE);
+                return true;
             }
-            if(internet.getVisibility() != View.VISIBLE)
-            {
+            if (internet.getVisibility() != View.VISIBLE) {
                 animate(internet);
                 internet.setVisibility(View.VISIBLE);
             }

--- a/app/src/main/java/com/stipess/youplay/utils/NetworkUtils.java
+++ b/app/src/main/java/com/stipess/youplay/utils/NetworkUtils.java
@@ -1,0 +1,70 @@
+package com.stipess.youplay.utils;
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkCapabilities;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public final class NetworkUtils {
+    private NetworkUtils() {}
+
+    public static boolean hasInternet(@NonNull Context context) {
+        ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        if (cm == null) return false;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            final AtomicBoolean connected = new AtomicBoolean(false);
+            final CountDownLatch latch = new CountDownLatch(1);
+            ConnectivityManager.NetworkCallback callback = new ConnectivityManager.NetworkCallback() {
+                @Override
+                public void onAvailable(@NonNull Network network) {
+                    connected.set(true);
+                    latch.countDown();
+                }
+
+                @Override
+                public void onUnavailable() {
+                    connected.set(false);
+                    latch.countDown();
+                }
+            };
+            cm.registerDefaultNetworkCallback(callback);
+            try {
+                latch.await(100, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException ignored) {}
+            cm.unregisterNetworkCallback(callback);
+            return connected.get();
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            Network network = cm.getActiveNetwork();
+            if (network == null) return false;
+            NetworkCapabilities caps = cm.getNetworkCapabilities(network);
+            return caps != null && (caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
+                    || caps.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)
+                    || caps.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)
+                    || caps.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH)
+                    || caps.hasTransport(NetworkCapabilities.TRANSPORT_VPN));
+        } else {
+            Network[] networks = cm.getAllNetworks();
+            for (Network network : networks) {
+                NetworkCapabilities caps = cm.getNetworkCapabilities(network);
+                if (caps != null && caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                        && (caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
+                        || caps.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)
+                        || caps.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)
+                        || caps.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH)
+                        || caps.hasTransport(NetworkCapabilities.TRANSPORT_VPN))) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- centralize network connectivity logic into `NetworkUtils`
- use `NetworkUtils` in `MainActivity`, `BaseFragment`, and `SearchFragment`
- remove deprecated `getActiveNetworkInfo` usage

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6844a2248278832c87581b734b494fb7