### PR TITLE
Fix PendingIntent flags for Android 12+

### DIFF
--- a/app/src/main/java/com/stipess/youplay/AudioService.java
+++ b/app/src/main/java/com/stipess/youplay/AudioService.java
@@ -377,19 +377,35 @@ public class AudioService extends Service implements AudioManager.OnAudioFocusCh
 
         Intent play_pause = new Intent(this, ButtonListener.class);
         play_pause.putExtra(ButtonListener.BUTTON, PLAY_PAUSE);
-        PendingIntent play_pause_btn = PendingIntent.getBroadcast(getApplicationContext(), 111, play_pause, 0);
+        PendingIntent play_pause_btn = PendingIntent.getBroadcast(
+                getApplicationContext(),
+                111,
+                play_pause,
+                PendingIntent.FLAG_IMMUTABLE);
 
         Intent next = new Intent(this, ButtonListener.class);
         next.putExtra(ButtonListener.BUTTON, NEXT);
-        PendingIntent next_btn = PendingIntent.getBroadcast(getApplicationContext(), 112, next, 0);
+        PendingIntent next_btn = PendingIntent.getBroadcast(
+                getApplicationContext(),
+                112,
+                next,
+                PendingIntent.FLAG_IMMUTABLE);
 
         Intent previous = new Intent(this, ButtonListener.class);
         previous.putExtra(ButtonListener.BUTTON, PREVIOUS);
-        PendingIntent previous_btn = PendingIntent.getBroadcast(getApplicationContext(), 113, previous, 0);
+        PendingIntent previous_btn = PendingIntent.getBroadcast(
+                getApplicationContext(),
+                113,
+                previous,
+                PendingIntent.FLAG_IMMUTABLE);
 
         Intent cancel = new Intent(this, ButtonListener.class);
         cancel.putExtra(ButtonListener.BUTTON, EXIT);
-        PendingIntent cancel_btn = PendingIntent.getBroadcast(getApplicationContext(), 114, cancel, 0);
+        PendingIntent cancel_btn = PendingIntent.getBroadcast(
+                getApplicationContext(),
+                114,
+                cancel,
+                PendingIntent.FLAG_IMMUTABLE);
 
         String id = "";
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
@@ -425,7 +441,11 @@ public class AudioService extends Service implements AudioManager.OnAudioFocusCh
             builder.setChannelId(id);
 
         Intent actionIntent = new Intent(this, MainActivity.class);
-        PendingIntent actionPendingIntent = PendingIntent.getActivity(this, 0, actionIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent actionPendingIntent = PendingIntent.getActivity(
+                this,
+                0,
+                actionIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
         builder.setContentIntent(actionPendingIntent);
 
         return builder.build();


### PR DESCRIPTION
## Summary
- add `FLAG_IMMUTABLE` to PendingIntent broadcasts
- make activity PendingIntent immutable

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6844a453d704832c9729c75ef5f2963c