### PR TITLE
Update height retrieval

### DIFF
--- a/app/src/main/java/com/stipess/youplay/fragments/PlayFragment.java
+++ b/app/src/main/java/com/stipess/youplay/fragments/PlayFragment.java
@@ -1018,8 +1018,7 @@ public class PlayFragment extends BaseFragment implements View.OnClickListener,
             Rect bounds = winMetrics.getBounds();
             heightPixels = bounds.height();
         } else {
-            DisplayMetrics metrics = new DisplayMetrics();
-            wm.getDefaultDisplay().getMetrics(metrics);
+            DisplayMetrics metrics = requireContext().getResources().getDisplayMetrics();
             heightPixels = metrics.heightPixels;
         }
 


### PR DESCRIPTION
## Summary
- use `WindowMetrics` API on newer Android versions
- fall back to context resources for display metrics to avoid deprecated APIs

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6844a4fe7af0832c8df1a1446001e1cb