### PR TITLE
Handle absent MediaStyle#setMediaSession

### DIFF
--- a/app/src/main/java/com/stipess/youplay/AudioService.java
+++ b/app/src/main/java/com/stipess/youplay/AudioService.java
@@ -434,9 +434,17 @@ public class AudioService extends Service implements AudioManager.OnAudioFocusCh
                 .addAction(drawable, "Play-Pause", play_pause_btn)
                 .addAction(R.drawable.next , "next", next_btn)
                 .addAction(R.drawable.cancel, "cancel", cancel_btn)
-                .setStyle(new androidx.media.app.NotificationCompat.MediaStyle().setMediaSession(mediaSessionCompat.getSessionToken()).setShowActionsInCompactView(0,1,2))
                 .setOngoing(true)
                 .setShowWhen(false);
+
+        androidx.media.app.NotificationCompat.MediaStyle style = new androidx.media.app.NotificationCompat.MediaStyle();
+        try {
+            style.getClass().getMethod("setMediaSession", MediaSessionCompat.Token.class)
+                    .invoke(style, mediaSessionCompat.getSessionToken());
+        } catch (Exception ignored) {
+        }
+        style.setShowActionsInCompactView(0,1,2);
+        builder.setStyle(style);
         if(id.equals("5385"))
             builder.setChannelId(id);
 


### PR DESCRIPTION
## Summary
- avoid `NoSuchMethodError` on some devices by reflecting the `setMediaSession` call when building the notification

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6844a57d7e28832c9d93271cdefe1aee