### PR TITLE
Fix crash due to invalid MediaButtonReceiver method

### DIFF
--- a/app/src/main/java/androidx/media/session/MediaButtonReceiver.java
+++ b/app/src/main/java/androidx/media/session/MediaButtonReceiver.java
@@ -1,7 +1,17 @@
 package androidx.media.session;
 
 import android.content.Intent;
+import android.view.KeyEvent;
 
+/**
+ * Minimal compatibility stub matching the AndroidX media library API.
+ * <p>
+ * This implementation simply returns {@code null}. It exists so the app can be
+ * built without bundling the full library while still providing the method
+ * signature expected at runtime.
+ */
 public class MediaButtonReceiver {
-    public static void handleIntent(MediaSessionCompat session, Intent intent) {}
+    public static KeyEvent handleIntent(MediaSessionCompat session, Intent intent) {
+        return null;
+    }
 }


### PR DESCRIPTION
## Summary
- fix `MediaButtonReceiver` stub signature to match androidx implementation

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6844a735e680832c80bec5e73fd95d46