### PR TITLE
Fix Glide thumbnail deprecation warning

### DIFF
--- a/app/src/main/java/com/stipess/youplay/adapter/VideoAdapter.java
+++ b/app/src/main/java/com/stipess/youplay/adapter/VideoAdapter.java
@@ -237,8 +237,18 @@ public class VideoAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
                     viewHolder.view.setText(stringBuilder1);
                     viewHolder.duration.setText(list.getDuration());
 
-                    Glide.with(context).load(FileManager.getPictureFile(list.getId())).thumbnail( 0.1f ).apply(new RequestOptions().diskCacheStrategy(DiskCacheStrategy.NONE).
-                            skipMemoryCache(true).format(DecodeFormat.PREFER_RGB_565).override(480,360)).into(viewHolder.image);
+                    Glide.with(context)
+                            .load(FileManager.getPictureFile(list.getId()))
+                            .thumbnail(
+                                    Glide.with(context)
+                                            .load(FileManager.getPictureFile(list.getId()))
+                                            .apply(new RequestOptions().override(100))
+                            )
+                            .apply(new RequestOptions().diskCacheStrategy(DiskCacheStrategy.NONE)
+                                    .skipMemoryCache(true)
+                                    .format(DecodeFormat.PREFER_RGB_565)
+                                    .override(480,360))
+                            .into(viewHolder.image);
 
                     if(list.getDownloaded() == 1)
                         viewHolder.downloaded.setText(R.string.you_downloaded);


### PR DESCRIPTION
## Summary
- replace deprecated `.thumbnail(float)` call with a `RequestBuilder` thumbnail

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6844abd102a0832cab98423772ff4c26