### PR TITLE
Fix deprecated keyboard APIs

### DIFF
--- a/app/src/main/java/com/stipess/youplay/MainActivity.java
+++ b/app/src/main/java/com/stipess/youplay/MainActivity.java
@@ -426,11 +426,10 @@ public class MainActivity extends AppCompatActivity implements AudioService.Serv
                         tabLayout.getTabAt(3).setIcon(R.drawable.radio);
 
                         searchView.requestFocus();
-//
                         if(imm == null)
                             imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
 
-                        imm.toggleSoftInput(InputMethodManager.SHOW_FORCED, InputMethodManager.SHOW_IMPLICIT);
+                        imm.showSoftInput(searchView, InputMethodManager.SHOW_IMPLICIT);
                         break;
 
                 }


### PR DESCRIPTION
## Summary
- update keyboard open logic to use `showSoftInput`

## Testing
- `./gradlew tasks --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6844ae1e72c8832c8851f24d12a72f68