### PR TITLE
Fix deprecation warning for getParcelableExtra

### DIFF
--- a/app/src/main/java/com/stipess/youplay/AudioService.java
+++ b/app/src/main/java/com/stipess/youplay/AudioService.java
@@ -32,6 +32,7 @@ import android.widget.RemoteViews;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
+import androidx.core.content.IntentCompat;
 import androidx.core.content.ContextCompat;
 import androidx.media.session.MediaButtonReceiver;
 import android.os.Parcelable;
@@ -530,11 +531,10 @@ public class AudioService extends Service implements AudioManager.OnAudioFocusCh
     }
 
     private <T extends Parcelable> T getParcelable(Intent intent, String key, Class<T> clazz) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             return intent.getParcelableExtra(key, clazz);
-        else
-            //noinspection deprecation
-            return intent.getParcelableExtra(key);
+        }
+        return IntentCompat.getParcelableExtra(intent, key);
     }
 
 


### PR DESCRIPTION
## Summary
- update `AudioService` to use `IntentCompat.getParcelableExtra`
- import `IntentCompat`

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6844b4dac4a0832c9084774bfff852be