### PR TITLE
Fix getParcelableExtra usage

### DIFF
--- a/app/src/main/java/com/stipess/youplay/AudioService.java
+++ b/app/src/main/java/com/stipess/youplay/AudioService.java
@@ -534,7 +534,7 @@ public class AudioService extends Service implements AudioManager.OnAudioFocusCh
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             return intent.getParcelableExtra(key, clazz);
         }
-        return IntentCompat.getParcelableExtra(intent, key);
+        return IntentCompat.getParcelableExtra(intent, key, clazz);
     }
 
 


### PR DESCRIPTION
## Summary
- update `getParcelable` method to use the new IntentCompat `getParcelableExtra` signature

## Testing
- `./gradlew assembleDebug` *(fails: unable to download Gradle wrapper due to network restriction)*

------
https://chatgpt.com/codex/tasks/task_e_6844b65d2384832c8575093725eb61bf