### PR TITLE
Update ViewPager2 version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -90,7 +90,8 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.viewpager2:viewpager2:1.1.0-beta02'
+    // Updated to stable release
+    implementation 'androidx.viewpager2:viewpager2:1.1.0'
     implementation 'androidx.media3:media3-exoplayer:1.7.1'
     implementation 'androidx.media3:media3-datasource:1.7.1'
     implementation 'androidx.media3:media3-extractor:1.7.1'

--- a/build.gradle
+++ b/build.gradle
@@ -24,3 +24,8 @@ allprojects {
 tasks.register("clean", Delete) {
     delete(rootProject.layout.buildDirectory)
 }
+
+// Ensure all Java compile tasks are configured lazily
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+}


### PR DESCRIPTION
## Summary
- bump ViewPager2 to 1.1.0
- configure JavaCompile tasks using `withType().configureEach`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6844b8f7eab4832c8a2a3c265d693ed8